### PR TITLE
fix: support Antigravity's new .antigravity-ide data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .vscode/
 .DS_Store
 Thumbs.db
+*.code-workspace

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,15 @@
 .vscode/**
+.claude/**
 src/**
 node_modules/**
 tsconfig.json
 esbuild.mjs
 **/*.map
+**/*.vsix
+**/.DS_Store
+.gitignore
+package-lock.json
+CLAUDE.md
+*.code-workspace
+llms.txt
+llms-small.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- **Fix Antigravity detection** — Antigravity renamed its data directory from `.antigravity` to `.antigravity-ide` in a recent release, so the extension could no longer find Claude Code's webview files and RTL stopped working. The finder now searches `.antigravity-ide` (and its server variant) first, falling back to the old `.antigravity` path for older installs.
+
 ## v0.4.0
 
 - **Custom font settings** — Two new VS Code settings let you choose the fonts Claude Code uses:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rtl",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rtl",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-rtl",
   "displayName": "Claude Code RTL Support",
   "description": "Adds RTL (Right-to-Left) text support for Hebrew, Arabic and Persian to Claude Code in VS Code, Cursor, Antigravity and Kiro",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "yechielby",
   "license": "MIT",
   "homepage": "https://github.com/YechielBy/claude-code-rtl-extension#readme",

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -97,17 +97,24 @@ async function getSearchDirectories(ide: Ide): Promise<string[]> {
     const platform = process.platform;
     const dirs: string[] = [];
 
-    const ideDirMap: Record<Ide, { local: string; server: string }> = {
-        vscode: { local: '.vscode', server: '.vscode-server' },
-        cursor: { local: '.cursor', server: '.cursor-server' },
-        antigravity: { local: '.antigravity', server: '.antigravity-server' },
-        kiro: { local: '.kiro', server: '.kiro-server' },
+    // Each IDE maps to one or more {local, server} dir-name pairs. Antigravity
+    // renamed its data dir from `.antigravity` to `.antigravity-ide` in a recent
+    // release; both are searched so old and new installs keep working.
+    const ideDirMap: Record<Ide, Array<{ local: string; server: string }>> = {
+        vscode: [{ local: '.vscode', server: '.vscode-server' }],
+        cursor: [{ local: '.cursor', server: '.cursor-server' }],
+        antigravity: [
+            { local: '.antigravity-ide', server: '.antigravity-ide-server' },
+            { local: '.antigravity', server: '.antigravity-server' },
+        ],
+        kiro: [{ local: '.kiro', server: '.kiro-server' }],
     };
 
     const addExtDirs = (home: string, ide: Ide) => {
-        const { local, server } = ideDirMap[ide];
-        dirs.push(path.join(home, local, 'extensions'));
-        dirs.push(path.join(home, server, 'extensions'));
+        for (const { local, server } of ideDirMap[ide]) {
+            dirs.push(path.join(home, local, 'extensions'));
+            dirs.push(path.join(home, server, 'extensions'));
+        }
     };
 
     if (platform === 'win32') {
@@ -119,8 +126,9 @@ async function getSearchDirectories(ide: Ide): Promise<string[]> {
         // Also search inside WSL distros
         const wslHomes = await getWslLinuxHomes();
         for (const wslHome of wslHomes) {
-            const serverDir = ideDirMap[ide].server;
-            dirs.push(path.join(wslHome, serverDir, 'extensions'));
+            for (const { server } of ideDirMap[ide]) {
+                dirs.push(path.join(wslHome, server, 'extensions'));
+            }
         }
     } else if (platform === 'darwin') {
         addExtDirs(os.homedir(), ide);


### PR DESCRIPTION
## Problem

Antigravity renamed its user data directory from `.antigravity` to `.antigravity-ide` in a recent release. The extension's finder only searched `~/.antigravity/extensions` (and the server variant), so on updated Antigravity installs it could no longer locate Claude Code's webview files. RTL injection silently stopped working — the live Claude Code extension now lives in `~/.antigravity-ide/extensions`.

## Fix

`ideDirMap` in `finder.ts` now maps each IDE to a **list** of `{local, server}` dir-name pairs. Antigravity searches `.antigravity-ide` (+ `.antigravity-ide-server`) first, then falls back to the legacy `.antigravity` path so older installs keep working. The WSL search loop was updated to iterate the pairs too.

Verified on macOS: finder now resolves the live `anthropic.claude-code-2.1.159` extension under `~/.antigravity-ide/extensions`, injection runs, and Hebrew text renders RTL in Antigravity IDE.

## Also included

- **`.vscodeignore` cleanup** — excludes dev-only files (`CLAUDE.md`, `.claude/`, `*.code-workspace`, `llms*.txt`, `*.vsix`, etc.) from the packaged VSIX. Package drops from 16 → 10 files.
- Version bump to 0.4.1 + changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)