### PR TITLE
fix: prevent file corruption when multiple IDE windows patch concurrently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .vscode/
 .DS_Store
 Thumbs.db
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/
 .DS_Store
 Thumbs.db
 *.code-workspace
+
+out-test/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,15 @@
 .vscode/**
+.claude/**
 src/**
 node_modules/**
 tsconfig.json
 esbuild.mjs
 **/*.map
+**/*.vsix
+**/.DS_Store
+.gitignore
+package-lock.json
+CLAUDE.md
+*.code-workspace
+llms.txt
+llms-small.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- **Fix Antigravity detection** — Antigravity renamed its data directory from `.antigravity` to `.antigravity-ide` in a recent release, so the extension could no longer find Claude Code's webview files and RTL stopped working. The finder now searches `.antigravity-ide` (and its server variant) first, falling back to the old `.antigravity` path for older installs.
+
 ## v0.4.0
 
 - **Custom font settings** — Two new VS Code settings let you choose the fonts Claude Code uses:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.4.2
+
+- **Fix file corruption with multiple IDE windows open** — Each open IDE window runs its own extension host, and they all patch the *same* Claude Code files on disk. Their backup/read/write cycles could interleave and truncate a file — in one report `webview/index.js` shrank from 4.8 MB to ~1 MB, which left the Claude panel completely blank. Injection is now:
+  - **Serialized** with a per-extension-directory lock file, so only one window patches at a time (stale locks are auto-broken; the lock never hangs the extension).
+  - **Atomic** — files are written to a temp path and renamed into place, so a reader never sees a half-written file.
+  - **Guarded** — since injection only adds content, a result smaller than the pristine backup is rejected instead of written, preventing truncation from being persisted.
+- Added a concurrency regression test (`npm test`) that patches one extension from 8 simulated windows at once and asserts no truncation, no stacked injections, pristine backups, and clean removal.
+
 ## v0.4.1
 
 - **Fix Antigravity detection** — Antigravity renamed its data directory from `.antigravity` to `.antigravity-ide` in a recent release, so the extension could no longer find Claude Code's webview files and RTL stopped working. The finder now searches `.antigravity-ide` (and its server variant) first, falling back to the old `.antigravity` path for older installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rtl",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rtl",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rtl",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rtl",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-rtl",
   "displayName": "Claude Code RTL Support",
   "description": "Adds RTL (Right-to-Left) text support for Hebrew, Arabic and Persian to Claude Code in VS Code, Cursor, Antigravity and Kiro",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "yechielby",
   "license": "MIT",
   "homepage": "https://github.com/YechielBy/claude-code-rtl-extension#readme",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-rtl",
   "displayName": "Claude Code RTL Support",
   "description": "Adds RTL (Right-to-Left) text support for Hebrew, Arabic and Persian to Claude Code in VS Code, Cursor, Antigravity and Kiro",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "yechielby",
   "license": "MIT",
   "homepage": "https://github.com/YechielBy/claude-code-rtl-extension#readme",
@@ -116,6 +116,8 @@
     "vscode:prepublish": "npm run build",
     "build": "node esbuild.mjs --production",
     "watch": "node esbuild.mjs --watch",
+    "pretest": "tsc -p tsconfig.test.json",
+    "test": "node test/concurrency.test.cjs",
     "package": "npx @vscode/vsce package"
   },
   "devDependencies": {

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -97,17 +97,24 @@ async function getSearchDirectories(ide: Ide): Promise<string[]> {
     const platform = process.platform;
     const dirs: string[] = [];
 
-    const ideDirMap: Record<Ide, { local: string; server: string }> = {
-        vscode: { local: '.vscode', server: '.vscode-server' },
-        cursor: { local: '.cursor', server: '.cursor-server' },
-        antigravity: { local: '.antigravity', server: '.antigravity-server' },
-        kiro: { local: '.kiro', server: '.kiro-server' },
+    // Each IDE maps to one or more {local, server} dir-name pairs. Antigravity
+    // renamed its data dir from `.antigravity` to `.antigravity-ide` in a recent
+    // release; both are searched so old and new installs keep working.
+    const ideDirMap: Record<Ide, Array<{ local: string; server: string }>> = {
+        vscode: [{ local: '.vscode', server: '.vscode-server' }],
+        cursor: [{ local: '.cursor', server: '.cursor-server' }],
+        antigravity: [
+            { local: '.antigravity-ide', server: '.antigravity-ide-server' },
+            { local: '.antigravity', server: '.antigravity-server' },
+        ],
+        kiro: [{ local: '.kiro', server: '.kiro-server' }],
     };
 
     const addExtDirs = (home: string, ide: Ide) => {
-        const { local, server } = ideDirMap[ide];
-        dirs.push(path.join(home, local, 'extensions'));
-        dirs.push(path.join(home, server, 'extensions'));
+        for (const { local, server } of ideDirMap[ide]) {
+            dirs.push(path.join(home, local, 'extensions'));
+            dirs.push(path.join(home, server, 'extensions'));
+        }
     };
 
     if (platform === 'win32') {
@@ -119,8 +126,9 @@ async function getSearchDirectories(ide: Ide): Promise<string[]> {
         // Also search inside WSL distros
         const wslHomes = await getWslLinuxHomes();
         for (const wslHome of wslHomes) {
-            const serverDir = ideDirMap[ide].server;
-            dirs.push(path.join(wslHome, serverDir, 'extensions'));
+            for (const { server } of ideDirMap[ide]) {
+                dirs.push(path.join(wslHome, server, 'extensions'));
+            }
         }
     } else if (platform === 'darwin') {
         addExtDirs(os.homedir(), ide);

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import * as path from 'path';
 import { ClaudeExtensionInfo, RtlStatus } from './types.js';
 import {
     RTL_JS_CODE,
@@ -26,6 +27,82 @@ async function exists(p: string): Promise<boolean> {
         return true;
     } catch {
         return false;
+    }
+}
+
+// ── Concurrency-safe file IO ──────────────────────────────────────
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn` while holding an exclusive lock file in `lockDir`.
+ *
+ * Every open IDE window runs its own extension host, and they all patch the
+ * SAME Claude Code files on disk. Without serialization their copyFile + read +
+ * write calls interleave and produce a torn/truncated file (observed: index.js
+ * shrinking from 4.8 MB to ~1 MB, which blanks the Claude panel). This lock
+ * guarantees one injection at a time per extension directory, across windows
+ * and processes.
+ *
+ * The lock is best-effort: a stale lock (older than STALE_MS, e.g. from a
+ * crashed window) is broken, and after MAX_WAIT_MS we proceed anyway rather
+ * than hang the extension forever.
+ */
+async function withFileLock<T>(lockDir: string, fn: () => Promise<T>): Promise<T> {
+    const lockPath = path.join(lockDir, '.ybyrtl.lock');
+    const STALE_MS = 30_000;
+    const RETRY_MS = 100;
+    const MAX_WAIT_MS = 20_000;
+
+    let handle: fs.FileHandle | undefined;
+    const start = Date.now();
+    while (true) {
+        try {
+            handle = await fs.open(lockPath, 'wx'); // exclusive create — fails if held
+            await handle.writeFile(String(process.pid));
+            break;
+        } catch (e) {
+            const err = e as NodeJS.ErrnoException;
+            if (err.code !== 'EEXIST') throw err;
+            try {
+                const st = await fs.stat(lockPath);
+                if (Date.now() - st.mtimeMs > STALE_MS) {
+                    await fs.rm(lockPath, { force: true });
+                    continue; // retry immediately after breaking a stale lock
+                }
+            } catch {
+                continue; // lock vanished between open and stat — retry
+            }
+            if (Date.now() - start > MAX_WAIT_MS) break; // proceed unlocked rather than hang
+            await delay(RETRY_MS);
+        }
+    }
+
+    try {
+        return await fn();
+    } finally {
+        if (handle) {
+            await handle.close().catch(() => { /* ignore */ });
+            await fs.rm(lockPath, { force: true }).catch(() => { /* ignore */ });
+        }
+    }
+}
+
+/**
+ * Write a file atomically: write to a unique temp file, then rename over the
+ * target. rename(2) is atomic on POSIX, so a reader (or a racing window) never
+ * observes a half-written file.
+ */
+async function atomicWrite(filePath: string, data: string): Promise<void> {
+    const tmpPath = `${filePath}.ybytmp.${process.pid}`;
+    try {
+        await fs.writeFile(tmpPath, data, 'utf-8');
+        await fs.rename(tmpPath, filePath);
+    } catch (e) {
+        await fs.rm(tmpPath, { force: true }).catch(() => { /* ignore */ });
+        throw e;
     }
 }
 
@@ -133,7 +210,17 @@ async function injectFile(
             messages.push(`  ${label}: Removed bidi-override rule`);
         }
 
-        await fs.writeFile(filePath, content + '\n' + injectedContent, 'utf-8');
+        const newContent = content + '\n' + injectedContent;
+        // Corruption guard: injection only ADDS content, so the result must be
+        // at least as large as the pristine backup. A smaller result means we
+        // read a torn file (e.g. a racing window truncated it) — abort without
+        // writing so the good backup is preserved.
+        const backupBytes = (await fs.stat(backupPath)).size;
+        if (Buffer.byteLength(newContent, 'utf-8') < backupBytes) {
+            messages.push(`  ${label}: Aborted — result (${Buffer.byteLength(newContent, 'utf-8')}B) smaller than backup (${backupBytes}B); corruption guard, file left untouched`);
+            return false;
+        }
+        await atomicWrite(filePath, newContent);
         return true;
     } catch (e: unknown) {
         const err = e as NodeJS.ErrnoException;
@@ -240,7 +327,15 @@ async function injectPlanPreview(
             }
         }
 
-        await fs.writeFile(extensionJsPath, content, 'utf-8');
+        // Corruption guard: Plan Preview injection only inserts content, so the
+        // result must be at least as large as the pristine backup. Bail out on a
+        // smaller result rather than persist a torn extension.js.
+        const backupBytes = (await fs.stat(backupPath)).size;
+        if (Buffer.byteLength(content, 'utf-8') < backupBytes) {
+            messages.push(`  Plan: Aborted — result (${Buffer.byteLength(content, 'utf-8')}B) smaller than backup (${backupBytes}B); corruption guard, file left untouched`);
+            return false;
+        }
+        await atomicWrite(extensionJsPath, content);
         messages.push('  Plan: RTL CSS injected into Plan Preview');
         return true;
     } catch (e: unknown) {
@@ -304,7 +399,7 @@ export async function getStatus(extensions: ClaudeExtensionInfo[]): Promise<RtlS
 /**
  * Add RTL support (Active mode) — CSS with .YBYrtl class + toggle button JS.
  */
-export async function addRtl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+async function addRtlImpl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
     const messages: string[] = [];
     let changed = false;
 
@@ -330,7 +425,7 @@ export async function addRtl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Pro
 /**
  * Add RTL "Always" mode — CSS without .YBYrtl class, no JS button.
  */
-export async function addRtlAlways(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+async function addRtlAlwaysImpl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
     const messages: string[] = [];
     let changed = false;
 
@@ -358,7 +453,7 @@ export async function addRtlAlways(ext: ClaudeExtensionInfo, fonts?: FontOptions
 /**
  * Add RTL "Auto" mode — per-element Hebrew detection via JS MutationObserver.
  */
-export async function addRtlAuto(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+async function addRtlAutoImpl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
     const messages: string[] = [];
     let changed = false;
 
@@ -385,17 +480,17 @@ export async function addRtlAuto(ext: ClaudeExtensionInfo, fonts?: FontOptions):
  * Add RTL support and fix BiDi issue by removing the bidi-override rule.
  * Preserves the current mode.
  */
-export async function fixBidi(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+async function fixBidiImpl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
     const currentlyAuto = await isAutoMode(ext.cssPath);
     const currentlyAlways = !currentlyAuto && await isAlwaysMode(ext.cssPath);
-    const result = currentlyAuto ? await addRtlAuto(ext, fonts) : currentlyAlways ? await addRtlAlways(ext, fonts) : await addRtl(ext, fonts);
+    const result = currentlyAuto ? await addRtlAutoImpl(ext, fonts) : currentlyAlways ? await addRtlAlwaysImpl(ext, fonts) : await addRtlImpl(ext, fonts);
 
     // After injection, remove the bidi-override rule if still present
     try {
         const content = await fs.readFile(ext.cssPath, 'utf-8');
         if (content.includes(BIDI_OVERRIDE)) {
             const fixed = content.replace(BIDI_OVERRIDE, '');
-            await fs.writeFile(ext.cssPath, fixed, 'utf-8');
+            await atomicWrite(ext.cssPath, fixed);
             result.messages.push(`  CSS: Removed bidi-override rule`);
         }
     } catch (e: unknown) {
@@ -434,7 +529,7 @@ async function removeInjected(
     try {
         const content = await fs.readFile(filePath, 'utf-8');
         const cleaned = stripBlock(content, startMarker, endMarker);
-        await fs.writeFile(filePath, cleaned, 'utf-8');
+        await atomicWrite(filePath, cleaned);
         messages.push(`  ${label}: RTL removed from ${extName}`);
         return true;
     } catch (e: unknown) {
@@ -446,7 +541,7 @@ async function removeInjected(
 /**
  * Remove RTL support from a single Claude Code extension.
  */
-export async function removeRtl(ext: ClaudeExtensionInfo): Promise<InjectionResult> {
+async function removeRtlImpl(ext: ClaudeExtensionInfo): Promise<InjectionResult> {
     const messages: string[] = [];
     let changed = false;
 
@@ -469,4 +564,31 @@ export async function removeRtl(ext: ClaudeExtensionInfo): Promise<InjectionResu
     }
 
     return { messages, changed };
+}
+
+// ── Public, lock-serialized entry points ──────────────────────────
+//
+// Every mutating operation runs under a per-extension-directory lock so that
+// concurrent IDE windows can't interleave their read-modify-write cycles and
+// corrupt the shared Claude Code files. The *Impl functions above stay
+// lock-free so fixBidi can compose them without deadlocking on the lock.
+
+export function addRtl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+    return withFileLock(ext.dir, () => addRtlImpl(ext, fonts));
+}
+
+export function addRtlAlways(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+    return withFileLock(ext.dir, () => addRtlAlwaysImpl(ext, fonts));
+}
+
+export function addRtlAuto(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+    return withFileLock(ext.dir, () => addRtlAutoImpl(ext, fonts));
+}
+
+export function fixBidi(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+    return withFileLock(ext.dir, () => fixBidiImpl(ext, fonts));
+}
+
+export function removeRtl(ext: ClaudeExtensionInfo): Promise<InjectionResult> {
+    return withFileLock(ext.dir, () => removeRtlImpl(ext));
 }

--- a/test/concurrency.test.cjs
+++ b/test/concurrency.test.cjs
@@ -1,0 +1,103 @@
+/**
+ * Regression test for concurrent-write corruption.
+ *
+ * Each open IDE window runs its own extension host, and they all patch the SAME
+ * Claude Code files on disk. Before the lock/atomic-write fix, their
+ * copyFile + read + write cycles interleaved and truncated the shared files
+ * (observed in the wild: webview/index.js shrinking from 4.8 MB to ~1 MB, which
+ * blanked the Claude panel).
+ *
+ * This test simulates several windows patching one extension simultaneously and
+ * asserts that the result is never truncated, backups stay pristine, injection
+ * doesn't stack, and removal restores the original.
+ *
+ * Run via `npm test` (compiles src -> out-test first).
+ */
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { addRtlAuto, removeRtl } = require('../out-test/injector.js');
+
+async function main() {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'ccrtl-race-'));
+  const extDir = path.join(tmp, 'anthropic.claude-code-9.9.9-test');
+  const webview = path.join(extDir, 'webview');
+  await fs.mkdir(webview, { recursive: true });
+
+  const cssPath = path.join(webview, 'index.css');
+  const jsPath = path.join(webview, 'index.js');
+  const extensionJsPath = path.join(extDir, 'extension.js');
+
+  // index.js is large (~5 MB) — the file that got truncated in the wild.
+  const bigJs = '/* claude code webview bundle */\n' + 'a'.repeat(5_000_000) + '\nexport{};\n';
+  const css = ':root{--x:1}\n.foo{color:red}\n';
+  // extension.js carries the Plan Preview template the injector edits.
+  const extJs =
+    'globalThis.x=1;\n<style>.p{a:b}</style>\n<div id="content"></div>\n' +
+    "vscode.postMessage({ type: 'ready' })\n";
+
+  await fs.writeFile(jsPath, bigJs);
+  await fs.writeFile(cssPath, css);
+  await fs.writeFile(extensionJsPath, extJs);
+
+  const origJs = (await fs.stat(jsPath)).size;
+  const origCss = (await fs.stat(cssPath)).size;
+  const origExt = (await fs.stat(extensionJsPath)).size;
+
+  const ext = {
+    dir: extDir,
+    cssPath,
+    jsPath,
+    extensionJsPath,
+    name: 'anthropic.claude-code-9.9.9-test',
+  };
+
+  // Simulate N IDE windows patching the SAME files at once.
+  const WINDOWS = 8;
+  await Promise.all(Array.from({ length: WINDOWS }, () => addRtlAuto(ext)));
+
+  const finalJs = (await fs.stat(jsPath)).size;
+  const finalCss = (await fs.stat(cssPath)).size;
+  const finalExt = (await fs.stat(extensionJsPath)).size;
+
+  // 1. No truncation: injection only adds, so the result must be >= original.
+  assert.ok(finalJs >= origJs, `index.js truncated! ${finalJs} < ${origJs}`);
+  assert.ok(finalCss >= origCss, `index.css shrank! ${finalCss} < ${origCss}`);
+  assert.ok(finalExt >= origExt, `extension.js shrank! ${finalExt} < ${origExt}`);
+
+  // 2. Backups are the pristine originals.
+  assert.strictEqual((await fs.stat(jsPath + '.bak')).size, origJs, 'js backup size drift');
+  assert.strictEqual((await fs.stat(cssPath + '.bak')).size, origCss, 'css backup size drift');
+
+  // 3. Injection happened exactly once — never stacked across windows.
+  const jsContent = await fs.readFile(jsPath, 'utf-8');
+  const cssContent = await fs.readFile(cssPath, 'utf-8');
+  const jsMarkers = (jsContent.match(/RTL Toggle Button - Added by script/g) || []).length;
+  assert.ok(cssContent.length > origCss, 'css RTL rules not injected');
+  assert.ok(jsMarkers <= 1, `JS injected ${jsMarkers}x (must never stack)`);
+  assert.ok(bigJs.length <= jsContent.length, 'original JS body lost');
+
+  // 4. No lock / temp litter left behind.
+  const leftovers = (await fs.readdir(extDir))
+    .concat(await fs.readdir(webview))
+    .filter((f) => f.includes('.ybyrtl.lock') || f.includes('.ybytmp'));
+  assert.strictEqual(leftovers.length, 0, `leftover lock/tmp files: ${leftovers}`);
+
+  // 5. removeRtl restores the original byte-for-byte.
+  await removeRtl(ext);
+  const restoredJs = (await fs.stat(jsPath)).size;
+  assert.strictEqual(restoredJs, origJs, `removeRtl did not restore index.js (${restoredJs} != ${origJs})`);
+
+  console.log(`PASS — ${WINDOWS} concurrent windows, no corruption`);
+  console.log(`  index.js  orig=${origJs} inject=${finalJs} remove=${restoredJs}`);
+  console.log(`  index.css orig=${origCss} inject=${finalCss}`);
+  console.log(`  JS markers after race: ${jsMarkers} (no stacking)`);
+
+  await fs.rm(tmp, { recursive: true, force: true });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "out-test",
+    "sourceMap": false,
+    "declaration": false
+  },
+  "include": ["src/injector.ts", "src/content.ts", "src/types.ts"]
+}


### PR DESCRIPTION
## Problem

Each open IDE window runs its own extension host, and they all patch the **same** Claude Code files on disk (`webview/index.js`, `webview/index.css`, `extension.js`). The injection path does an unsynchronized read-modify-write (`copyFile` backup → `readFile` → `writeFile`) with no lock between windows/processes.

With more than one window open, these cycles interleave and tear the file. In a real report on **Antigravity IDE**, `webview/index.js` was truncated from **4.8 MB → ~1 MB** right after a Claude Code reinstall (which re-triggered patching in every window). The truncated webview bundle fails to load → **the Claude panel renders completely blank** and sessions appear gone. Restoring from the `.bak` brought it back, confirming the on-disk file was the corrupted artifact.

This is separate from #11 (which fixes *which directory* is searched); this fixes *how* the files are written.

## Fix

`src/injector.ts`:

- **Serialize** every mutating op behind a per-extension-directory lock file (`withFileLock`), so only one window patches at a time. Stale locks (crashed window) are auto-broken after 30s, and it falls through after a bounded wait rather than ever hanging the extension.
- **Atomic writes** (`atomicWrite`): write to a unique temp file then `rename()` into place, so a reader/racing window never observes a half-written file.
- **Corruption guard**: injection only *adds* content, so a result smaller than the pristine backup is rejected instead of written — truncation can never be persisted.
- Public functions (`addRtl`, `addRtlAlways`, `addRtlAuto`, `fixBidi`, `removeRtl`) are now thin lock-serialized wrappers over lock-free `*Impl` functions, so `fixBidi` composes them without re-entrant deadlock.

## Test

Adds `test/concurrency.test.cjs` (run with `npm test`): patches one extension from **8 simulated windows concurrently** and asserts no truncation, no stacked injections, pristine backups, and clean removal. The pre-fix code truncates/hangs under the same race; the fixed code passes.

```
PASS — 8 concurrent windows, no corruption
  index.js  orig=5000044 inject=5004129 remove=5000044
  index.css orig=29 inject=4929
  JS markers after race: 1 (no stacking)
```

Verified: `tsc --noEmit` clean, `npm run build` clean, `npm test` passes. Bumped to v0.4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)