### PR TITLE
Fix Antigravity extension discovery for new .antigravity-ide path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-rtl",
   "displayName": "Claude Code RTL Support",
   "description": "Adds RTL (Right-to-Left) text support for Hebrew, Arabic and Persian to Claude Code in VS Code, Cursor, Antigravity and Kiro",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "yechielby",
   "license": "MIT",
   "homepage": "https://github.com/YechielBy/claude-code-rtl-extension#readme",

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -97,17 +97,24 @@ async function getSearchDirectories(ide: Ide): Promise<string[]> {
     const platform = process.platform;
     const dirs: string[] = [];
 
-    const ideDirMap: Record<Ide, { local: string; server: string }> = {
+    const ideDirMap: Record<Ide, { local: string; server: string; extra?: string[] }> = {
         vscode: { local: '.vscode', server: '.vscode-server' },
         cursor: { local: '.cursor', server: '.cursor-server' },
-        antigravity: { local: '.antigravity', server: '.antigravity-server' },
+        // Newer Antigravity builds moved extensions to ~/.antigravity-ide/extensions.
+        // Keep the legacy ~/.antigravity as a fallback for older installs.
+        antigravity: { local: '.antigravity-ide', server: '.antigravity-server', extra: ['.antigravity'] },
         kiro: { local: '.kiro', server: '.kiro-server' },
     };
 
     const addExtDirs = (home: string, ide: Ide) => {
-        const { local, server } = ideDirMap[ide];
+        const { local, server, extra } = ideDirMap[ide];
         dirs.push(path.join(home, local, 'extensions'));
         dirs.push(path.join(home, server, 'extensions'));
+        if (extra) {
+            for (const extraDir of extra) {
+                dirs.push(path.join(home, extraDir, 'extensions'));
+            }
+        }
     };
 
     if (platform === 'win32') {


### PR DESCRIPTION
## Problem

Newer Antigravity builds moved the extensions directory from `~/.antigravity/extensions` to `~/.antigravity-ide/extensions`. The finder in `src/finder.ts` only searched `.antigravity` / `.antigravity-server`, so on current Antigravity installs it never found the `anthropic.claude-code-*/webview` files — RTL injection silently did nothing (no error, just no effect).

Verified on macOS: the live Claude Code extension (`anthropic.claude-code-2.1.177`) now installs under `~/.antigravity-ide/extensions`, while the extension was still looking in `~/.antigravity/extensions`.

## Fix

`getSearchDirectories` now searches `.antigravity-ide` first and keeps the legacy `.antigravity` as a fallback, via a new optional `extra` dir list on the IDE map. Both new and old Antigravity installs work; other IDEs are unaffected (no `extra` set).

```ts
antigravity: { local: '.antigravity-ide', server: '.antigravity-server', extra: ['.antigravity'] },
```

## Testing

- `npx tsc --noEmit` — clean
- `npm run build` — bundled `dist/extension.js` contains both `.antigravity-ide` and the legacy fallback path
- Manually confirmed RTL CSS injects into `anthropic.claude-code-2.1.177` under `~/.antigravity-ide/extensions` after the change

Note: version bumped to `0.4.1` + changelog entry — adjust to fit your release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)