### PR TITLE
fix: prevent English text right-alignment in Opus caused by BOM

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -298,7 +298,7 @@ const PERMISSION_RTL_CSS = `
 /** JS for dynamic permission RTL detection — shared across all modes */
 const PERMISSION_RTL_JS = `
 (function() {
-    var PERM_RTL_RE = /[\\u0590-\\u05FF\\u0600-\\u06FF\\u0750-\\u077F\\uFB50-\\uFDFF\\uFE70-\\uFEFF]/;
+    var PERM_RTL_RE = /[\\u0590-\\u05FF\\u0600-\\u06FF\\u0750-\\u077F\\uFB50-\\uFDFF\\uFE70-\\uFEFE]/;
     var PERM_SEL = '[class*="permissionsContainer_"]';
 
     var LABEL_SEL = '[class*="optionLabel_"],[class*="optionDescription_"]';
@@ -680,7 +680,7 @@ export const PLAN_ACTIVE_JS =
 export const PLAN_AUTO_JS =
     PLAN_JS_START_MARKER + '\n' +
     `(function() {
-    var RTL_RE = /[\\u0590-\\u05FF\\u0600-\\u06FF\\u0750-\\u077F\\uFB50-\\uFDFF\\uFE70-\\uFEFF]/;
+    var RTL_RE = /[\\u0590-\\u05FF\\u0600-\\u06FF\\u0750-\\u077F\\uFB50-\\uFDFF\\uFE70-\\uFEFE]/;
     var content = document.getElementById('content');
     if (!content) return;
     var btn = document.createElement('button');
@@ -712,7 +712,7 @@ export const PLAN_AUTO_JS =
 export const RTL_AUTO_JS_CODE = `
 /* RTL Toggle Button - Added by script */
 (function() {
-    var RTL = /[\\u0590-\\u05FF\\u0600-\\u06FF\\u0750-\\u077F\\uFB50-\\uFDFF\\uFE70-\\uFEFF]/;
+    var RTL = /[\\u0590-\\u05FF\\u0600-\\u06FF\\u0750-\\u077F\\uFB50-\\uFDFF\\uFE70-\\uFEFE]/;
     var CLS = 'YBYrtl';
 
     /* Bubble selectors — Claude responses and user messages */


### PR DESCRIPTION
## Description

When using the Opus model, English text was sometimes mistakenly aligned to the right (RTL). This happened because the Opus model often outputs the BOM (Byte Order Mark, \\uFEFF\) character.

The regex used to detect RTL text ended with \\uFEFF\: ar RTL = /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\uFB50-\uFDFF\uFE70-\uFEFF]/;. 

This character (\\uFEFF\) is a Zero Width No-Break Space, which does not belong to the Arabic or Hebrew character sets, but it happened to be the last character of the Arabic Presentation Forms-B block.

This PR fixes the issue by excluding \\uFEFF\ and ending the regex at \\uFEFE\ instead.