### PR TITLE
feat: add Force LTR (Always) mode — direction as a user choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **New: Force LTR (Always) mode** (`Claude RTL: Force LTR (Always)`) — pins the whole chat (messages, input box, question/permission dialogs, Plan Preview) to left-to-right, even when the conversation contains Hebrew, Arabic, or Persian text. The direction choice is now symmetric: users who want RTL pick an RTL mode, users who prefer a stable LTR layout while chatting in an RTL language pick LTR Always. Shown in the status bar as `LTR: Always` and available from the status-bar menu; survives Claude Code updates via auto-reactivate like the other modes.
+
 ## v0.4.2
 
 - **Fix file corruption with multiple IDE windows open** — Each open IDE window runs its own extension host, and they all patch the *same* Claude Code files on disk. Their backup/read/write cycles could interleave and truncate a file — in one report `webview/index.js` shrank from 4.8 MB to ~1 MB, which left the Claude panel completely blank. Injection is now:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The original `Claude Code for VS Code` extension lacks native RTL support. This 
 | ▶️ Activate RTL | Injects CSS and a toggle button into the Claude Code chat |
 | 📌 Activate RTL (Always) | Permanently enables RTL without a toggle button |
 | 👁️ Activate RTL (Auto) | Auto-detects Hebrew/Arabic/Persian per bubble and sets direction **(Recommended)** |
+| ➡️ Force LTR (Always) | Forces left-to-right always — even for Hebrew/Arabic/Persian text |
 | 🔧 Fix BiDi | Activates RTL and fixes reversed text (e.g. "םולש" → "שלום") |
 | ⏹️ Deactivate RTL | Restores original files from backup |
 | 🔍 Check Status | Shows which installations have RTL enabled |
@@ -149,6 +150,7 @@ After installation, a status bar item appears at the bottom of VS Code:
 | `RTL: Active` ✅ | RTL is injected with toggle button |
 | `RTL: Always` 📌 | RTL is permanently on (no toggle needed) |
 | `RTL: Auto` 👁️ | RTL auto-detects per bubble **(Recommended)** |
+| `LTR: Always` ➡️ | Layout is forced left-to-right, even for RTL text |
 | `RTL: Inactive` ⭕ | RTL is not installed |
 | `RTL: N/A` ❌ | Claude Code for VS Code extension not found |
 
@@ -163,6 +165,7 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS) and search for:
 | `Claude RTL: Activate RTL` | ▶️ Enable RTL support with toggle button |
 | `Claude RTL: Activate RTL (Always)` | 📌 Enable RTL permanently without toggle button |
 | `Claude RTL: Activate RTL (Auto)` | 👁️ Auto-detect RTL per bubble **(Recommended)** |
+| `Claude RTL: Force LTR (Always)` | ➡️ Force left-to-right always, even for RTL text |
 | `Claude RTL: Fix BiDi` | 🔧 Activate RTL + fix bidirectional text issues |
 | `Claude RTL: Deactivate RTL` | ⏹️ Disable RTL and restore original files |
 | `Claude RTL: Check Status` | 🔍 View installation status |
@@ -181,6 +184,8 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS) and search for:
 **Always mode** — RTL is permanently on. No button needed — text is always right-to-left.
 
 **Auto mode** — RTL is automatically detected per chat bubble. Bubbles with Hebrew/Arabic/Persian text become RTL; English-only bubbles stay LTR. Best for mixed-language conversations.
+
+**LTR Always mode** — the opposite direction choice: the whole chat (messages, input box, Plan Preview) is pinned left-to-right, even when the conversation contains Hebrew, Arabic, or Persian text. For users who read RTL languages comfortably but prefer a stable LTR layout while coding.
 
 > 💡 **Tip (Active mode):** Not every conversation needs RTL — you can toggle it per chat session.
 > Use ⇄ only in conversations where you write in Hebrew, Arabic, or Persian.

--- a/package.json
+++ b/package.json
@@ -99,6 +99,10 @@
         "title": "Claude RTL: Activate RTL (Auto)"
       },
       {
+        "command": "claude-rtl.addLtr",
+        "title": "Claude RTL: Force LTR (Always)"
+      },
+      {
         "command": "claude-rtl.remove",
         "title": "Claude RTL: Deactivate RTL"
       },

--- a/src/content.ts
+++ b/src/content.ts
@@ -16,6 +16,7 @@ export const JS_END_MARKER = '/* End RTL Toggle Button */';
 export const RTL_MODE_ACTIVE_MARKER = '/* RTL-MODE: active */';
 export const RTL_MODE_ALWAYS_MARKER = '/* RTL-MODE: always */';
 export const RTL_MODE_AUTO_MARKER = '/* RTL-MODE: auto */';
+export const RTL_MODE_LTR_MARKER = '/* RTL-MODE: ltr */';
 
 // ── CSS Building Blocks ───────────────────────────────────────────
 
@@ -202,6 +203,67 @@ ${p}[class*="thinkingContent_"] [class*="root_"] :is(ul, ol, li) {
 }
 `;
 }
+
+/** Force-LTR content rules — unprefixed (LTR Always mode).
+ *  Pins every content surface to left-to-right, overriding the webview's
+ *  auto direction detection, so Hebrew/Arabic text renders in an LTR layout. */
+const LTR_CONTENT_RULES = `
+/* ==========================================
+   LTR - Force left-to-right always
+   ========================================== */
+
+/* Messages container */
+[class*="messagesContainer_"] {
+    direction: ltr;
+}
+
+/* User messages */
+[class*="userMessage_"],
+[class*="userMessageContainer_"] {
+    direction: ltr;
+    unicode-bidi: isolate;
+    text-align: left !important;
+}
+
+[class*="content_"][class*="xGDvVg"],
+[class*="content_"] > span {
+    unicode-bidi: isolate;
+}
+
+/* Claude's markdown responses */
+[class*="root_"] {
+    direction: ltr;
+    unicode-bidi: isolate;
+}
+
+[class*="root_"] > :is(p, ul, ol, h1, h2, h3, h4, blockquote),
+[class*="root_"] > :is(ul, ol) li {
+    text-align: left;
+}
+
+/* Question/answer blocks */
+[class*="questionBlock_"],
+[class*="questionHeader_"],
+[class*="answerText_"],
+[class*="optionText_"],
+[class*="optionContent_"],
+[class*="optionLabel_"],
+[class*="optionDescription_"],
+[class*="permissionsContainer_"],
+[class*="permissionRequestContent_"] {
+    direction: ltr;
+    unicode-bidi: isolate;
+    text-align: left;
+}
+
+/* Prompt input — force LTR instead of auto-detecting by first character */
+[class*="messageInputContainer_"] > *,
+[class*="otherInput_"] [contenteditable] {
+    direction: ltr;
+    unicode-bidi: isolate;
+    text-align: left;
+}
+`;
 
 /** Auto mode RTL rules — .YBYrtl is on the bubble itself, not on #root.
  *  Uses descendant selectors from the bubble, plus self-matching for the bubble element. */
@@ -469,6 +531,15 @@ export function generateAutoCssRules(fonts: FontOptions = NO_FONTS): string {
     ]);
 }
 
+/** LTR Always mode — force left-to-right everywhere, no prefix, no button */
+export function generateLtrCssRules(fonts: FontOptions = NO_FONTS): string {
+    return assembleCss(RTL_MODE_LTR_MARKER, [
+        LTR_CONTENT_RULES,
+        ltrOverrideRules(''),
+        generateFontCss(fonts),
+    ]);
+}
+
 // ── JavaScript ────────────────────────────────────────────────────
 
 /** RTL JS toggle button code */
@@ -644,6 +715,32 @@ export function generatePlanActiveCss(fonts: FontOptions = NO_FONTS): string {
 export function generatePlanAlwaysCss(fonts: FontOptions = NO_FONTS): string {
     return PLAN_CSS_START_MARKER + '\n' +
         PLAN_RTL_ALWAYS_CSS +
+        generatePlanFontCss(fonts) +
+        '\n' + PLAN_CSS_END_MARKER;
+}
+
+/** Plan Preview force-LTR rules — unscoped (LTR Always mode) */
+const PLAN_LTR_ALWAYS_CSS = `
+#content {
+    direction: ltr;
+    unicode-bidi: isolate;
+    text-align: left;
+}
+#content th, #content td {
+    text-align: left;
+}
+#content pre,
+#content code {
+    direction: ltr;
+    unicode-bidi: isolate;
+    text-align: left;
+}
+`;
+
+/** Assembled Plan Preview CSS for LTR Always mode */
+export function generatePlanLtrCss(fonts: FontOptions = NO_FONTS): string {
+    return PLAN_CSS_START_MARKER + '\n' +
+        PLAN_LTR_ALWAYS_CSS +
         generatePlanFontCss(fonts) +
         '\n' + PLAN_CSS_END_MARKER;
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -212,17 +212,22 @@ const LTR_CONTENT_RULES = `
    LTR - Force left-to-right always
    ========================================== */
 
-/* Messages container */
+/* Messages container — anchor all bubbles to the left edge */
 [class*="messagesContainer_"] {
     direction: ltr;
+    align-items: flex-start !important;
 }
 
-/* User messages */
+/* User messages — pinned to the left, mirroring how RTL Always pins right */
 [class*="userMessage_"],
 [class*="userMessageContainer_"] {
     direction: ltr;
     unicode-bidi: isolate;
     text-align: left !important;
+    align-items: flex-start !important;
+    align-self: flex-start !important;
+    margin-left: 0 !important;
+    margin-right: auto !important;
 }
 
 [class*="content_"][class*="xGDvVg"],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ClaudeExtensionInfo, RtlMode } from './types.js';
 import { findClaudeExtensions } from './finder.js';
-import { addRtl, addRtlAlways, addRtlAuto, removeRtl, fixBidi, getStatus } from './injector.js';
+import { addRtl, addRtlAlways, addRtlAuto, addLtrAlways, removeRtl, fixBidi, getStatus } from './injector.js';
 import { FontOptions } from './content.js';
 import { createStatusBarItem, updateStatusBar, disposeStatusBar } from './statusBar.js';
 
@@ -120,6 +120,7 @@ async function handleShowMenu(): Promise<void> {
         { label: '$(check) Activate RTL', description: 'Enable RTL support with toggle button', command: 'claude-rtl.add' },
         { label: '$(pin) Activate RTL (Always)', description: 'Enable RTL permanently without toggle button', command: 'claude-rtl.addAlways' },
         { label: '$(eye) Activate RTL (Auto)', description: 'Auto-detect RTL text per paragraph and set direction', command: 'claude-rtl.addAuto' },
+        { label: '$(arrow-right) Force LTR (Always)', description: 'Force left-to-right always, even for Hebrew/Arabic/Persian text', command: 'claude-rtl.addLtr' },
         { label: '$(tools) Fix BiDi', description: 'Activate RTL and fix bidirectional text issues', command: 'claude-rtl.fixBidi' },
         { label: '$(close) Deactivate RTL', description: 'Disable RTL support and restore original files', command: 'claude-rtl.remove' },
         { label: '$(info) Check Status', description: 'Show current RTL status', command: 'claude-rtl.status' },
@@ -138,6 +139,7 @@ const MODE_ACTIONS: Record<string, InjectionAction> = {
     active: addRtl,
     always: addRtlAlways,
     auto: addRtlAuto,
+    ltr: addLtrAlways,
 };
 
 async function silentInject(extensions: ClaudeExtensionInfo[], action: InjectionAction, fonts?: FontOptions): Promise<boolean> {
@@ -280,6 +282,7 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand('claude-rtl.add', () => handleMode('Activating RTL support', 'active', addRtl)),
         vscode.commands.registerCommand('claude-rtl.addAlways', () => handleMode('Activating RTL Always mode', 'always', addRtlAlways)),
         vscode.commands.registerCommand('claude-rtl.addAuto', () => handleMode('Activating RTL Auto mode', 'auto', addRtlAuto)),
+        vscode.commands.registerCommand('claude-rtl.addLtr', () => handleMode('Activating LTR Always mode', 'ltr', addLtrAlways)),
         vscode.commands.registerCommand('claude-rtl.fixBidi', handleFixBidi),
         vscode.commands.registerCommand('claude-rtl.remove', handleRemove),
         vscode.commands.registerCommand('claude-rtl.status', handleStatus),

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -5,14 +5,15 @@ import {
     RTL_JS_CODE,
     RTL_START_MARKER, RTL_END_MARKER,
     JS_START_MARKER, JS_END_MARKER,
-    RTL_MODE_ALWAYS_MARKER, RTL_MODE_AUTO_MARKER,
+    RTL_MODE_ALWAYS_MARKER, RTL_MODE_AUTO_MARKER, RTL_MODE_LTR_MARKER,
     RTL_AUTO_JS_CODE,
-    generateActiveCssRules, generateAlwaysCssRules, generateAutoCssRules,
+    generateActiveCssRules, generateAlwaysCssRules, generateAutoCssRules, generateLtrCssRules,
     PLAN_CSS_START_MARKER, PLAN_CSS_END_MARKER,
     PLAN_JS_START_MARKER, PLAN_JS_END_MARKER,
     generatePlanActiveCss, PLAN_ACTIVE_JS,
     generatePlanAlwaysCss,
     generatePlanAutoCss, PLAN_AUTO_JS,
+    generatePlanLtrCss,
     FontOptions,
 } from './content.js';
 
@@ -137,6 +138,18 @@ export async function isAutoMode(cssPath: string): Promise<boolean> {
     try {
         const content = await fs.readFile(cssPath, 'utf-8');
         return content.includes(RTL_MODE_AUTO_MARKER);
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Check if CSS is in "ltr" mode (force left-to-right always).
+ */
+export async function isLtrMode(cssPath: string): Promise<boolean> {
+    try {
+        const content = await fs.readFile(cssPath, 'utf-8');
+        return content.includes(RTL_MODE_LTR_MARKER);
     } catch {
         return false;
     }
@@ -378,7 +391,8 @@ export async function getStatus(extensions: ClaudeExtensionInfo[]): Promise<RtlS
 
         const cssInstalled = cssContent.includes(RTL_START_MARKER);
         const autoMode = cssInstalled && cssContent.includes(RTL_MODE_AUTO_MARKER);
-        const alwaysMode = cssInstalled && !autoMode && cssContent.includes(RTL_MODE_ALWAYS_MARKER);
+        const ltrMode = cssInstalled && !autoMode && cssContent.includes(RTL_MODE_LTR_MARKER);
+        const alwaysMode = cssInstalled && !autoMode && !ltrMode && cssContent.includes(RTL_MODE_ALWAYS_MARKER);
 
         statuses.push({
             extension: ext,
@@ -387,7 +401,7 @@ export async function getStatus(extensions: ClaudeExtensionInfo[]): Promise<RtlS
             planPreviewInstalled: await isPlanPreviewInstalled(ext.extensionJsPath),
             cssBackupExists: await exists(ext.cssPath + '.bak'),
             jsBackupExists: ext.jsPath ? await exists(ext.jsPath + '.bak') : false,
-            mode: autoMode ? 'auto' : alwaysMode ? 'always' : cssInstalled ? 'active' : 'inactive',
+            mode: autoMode ? 'auto' : ltrMode ? 'ltr' : alwaysMode ? 'always' : cssInstalled ? 'active' : 'inactive',
         });
     }
 
@@ -477,13 +491,44 @@ async function addRtlAutoImpl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Pr
 }
 
 /**
+ * Add "LTR Always" mode — force left-to-right everywhere, no JS button.
+ * Gives users of LTR languages a way to pin the layout even when the
+ * conversation contains Hebrew/Arabic text.
+ */
+async function addLtrAlwaysImpl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+    const messages: string[] = [];
+    let changed = false;
+
+    if (await injectFile(ext.cssPath, generateLtrCssRules(fonts), 'CSS', messages, { fixBidi: true })) {
+        messages.push(`  CSS: LTR Always support added to ${ext.name}`);
+        changed = true;
+    }
+
+    // Remove JS button if installed
+    if (ext.jsPath && await isJsInstalled(ext.jsPath)) {
+        if (await restoreAndDeleteBackup(ext.jsPath, 'JS', messages)) {
+            changed = true;
+        }
+    } else {
+        messages.push(`  JS:  No button to remove (LTR Always mode — no JS needed)`);
+    }
+
+    if (await injectPlanPreview(ext.extensionJsPath, generatePlanLtrCss(fonts), null, messages)) {
+        changed = true;
+    }
+
+    return { messages, changed };
+}
+
+/**
  * Add RTL support and fix BiDi issue by removing the bidi-override rule.
  * Preserves the current mode.
  */
 async function fixBidiImpl(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
     const currentlyAuto = await isAutoMode(ext.cssPath);
-    const currentlyAlways = !currentlyAuto && await isAlwaysMode(ext.cssPath);
-    const result = currentlyAuto ? await addRtlAutoImpl(ext, fonts) : currentlyAlways ? await addRtlAlwaysImpl(ext, fonts) : await addRtlImpl(ext, fonts);
+    const currentlyLtr = !currentlyAuto && await isLtrMode(ext.cssPath);
+    const currentlyAlways = !currentlyAuto && !currentlyLtr && await isAlwaysMode(ext.cssPath);
+    const result = currentlyAuto ? await addRtlAutoImpl(ext, fonts) : currentlyLtr ? await addLtrAlwaysImpl(ext, fonts) : currentlyAlways ? await addRtlAlwaysImpl(ext, fonts) : await addRtlImpl(ext, fonts);
 
     // After injection, remove the bidi-override rule if still present
     try {
@@ -583,6 +628,10 @@ export function addRtlAlways(ext: ClaudeExtensionInfo, fonts?: FontOptions): Pro
 
 export function addRtlAuto(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
     return withFileLock(ext.dir, () => addRtlAutoImpl(ext, fonts));
+}
+
+export function addLtrAlways(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {
+    return withFileLock(ext.dir, () => addLtrAlwaysImpl(ext, fonts));
 }
 
 export function fixBidi(ext: ClaudeExtensionInfo, fonts?: FontOptions): Promise<InjectionResult> {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -27,12 +27,16 @@ export async function updateStatusBar(): Promise<void> {
 
     const statuses = await getStatus(extensions);
     const autoMode = statuses.some(s => s.mode === 'auto');
+    const ltrMode = statuses.some(s => s.mode === 'ltr');
     const alwaysMode = statuses.some(s => s.mode === 'always');
     const activeMode = statuses.some(s => s.mode === 'active');
 
     if (autoMode) {
         statusBarItem.text = '$(globe) RTL: Auto';
         statusBarItem.tooltip = 'Claude Code RTL auto-detects direction. Click to manage.';
+    } else if (ltrMode) {
+        statusBarItem.text = '$(globe) LTR: Always';
+        statusBarItem.tooltip = 'Claude Code is forced left-to-right. Click to manage.';
     } else if (alwaysMode) {
         statusBarItem.text = '$(globe) RTL: Always';
         statusBarItem.tooltip = 'Claude Code RTL is always on. Click to manage.';

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,8 @@ export interface ClaudeExtensionInfo {
     name: string;
 }
 
-/** RTL operating mode */
-export type RtlMode = 'active' | 'always' | 'auto' | 'inactive';
+/** RTL operating mode — 'ltr' forces left-to-right always, even for RTL scripts */
+export type RtlMode = 'active' | 'always' | 'auto' | 'ltr' | 'inactive';
 
 /** RTL installation status for a single extension */
 export interface RtlStatus {


### PR DESCRIPTION
## What

Adds a fifth mode, **`ltr`** (Force LTR Always), alongside the existing `active` / `always` / `auto` / `inactive` modes — making the direction setting a symmetric user choice: users who want RTL pick an RTL mode, users who prefer a stable left-to-right layout while chatting in Hebrew/Arabic/Persian pick LTR Always.

- New command **`Claude RTL: Force LTR (Always)`** (`claude-rtl.addLtr`), also added to the status-bar QuickPick menu.
- Injects unprefixed CSS that pins messages, markdown responses, question/permission blocks, the prompt input, and Plan Preview to `direction: ltr; unicode-bidi: isolate; text-align: left` — overriding the webview'\''s per-first-character auto direction detection.
- Own mode marker `/* RTL-MODE: ltr */`, so status detection, `fixBidi` mode preservation, and **auto-reactivation after Claude Code updates** all work exactly like the existing modes.
- Status bar shows **`LTR: Always`**.

## Why

Some users of RTL languages prefer their *coding* chat pinned LTR — code snippets, file paths, and mixed technical text dominate, and the constant direction flipping is disruptive. Today the only options are flavors of RTL or full deactivation, and deactivation still leaves the webview auto-flipping the input line the moment a message starts with an RTL character. This came from a real Arabic-speaking user request.

## How

Deliberately mirrors the existing `always` mode implementation end-to-end: same `injectFile` / `withFileLock` / backup / corruption-guard machinery, same Plan Preview injection path, no JS needed (button removed like Always mode). **Zero behavior change for any existing mode.**

## Tested

- `npx tsc --noEmit` — clean
- `npm run build` (esbuild production) — clean; verified `RTL-MODE: ltr`, `claude-rtl.addLtr`, and the menu entry are present in the built bundle
- `npm test` (8-window concurrency test) — PASS
- Manually verified the LTR CSS ruleset against Claude Code 2.1.217 on Windows (VS Code): Arabic messages, input box, permission dialogs, and Plan Preview all render pinned LTR; switching back to RTL modes and Deactivate restore correctly.

## Notes

- README updated in the **English** section only (features table, status-bar table, command table, usage). Happy to add the Hebrew/Arabic/Persian translations too if you'\''d like — or leave them to you for phrasing.
- CHANGELOG entry added under `Unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)