### PR TITLE
fix(security): sanitize user-controlled font settings before CSS/webview injection

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -435,10 +435,27 @@ export interface FontOptions {
 export const NO_FONTS: FontOptions = { textFont: '', codeFont: '' };
 
 /** Generate font CSS for chat — applied universally (independent of RTL state). */
+/**
+ * Sanitize a user-supplied font-family name before it is interpolated into CSS.
+ *
+ * textFont/codeFont come from `claude-code-rtl.*` settings, which VS Code reads
+ * at workspace scope (a repo's .vscode/settings.json). The value is interpolated
+ * into `font-family: "${value}"` and, on the Plan Preview path, into a <style>
+ * block that lives inside Claude Code's webview HTML. Without sanitizing, a value
+ * such as `Arial"; } </style><script>...` breaks out of the string, the rule, and
+ * the <style> element. Font-family names are letters, digits, spaces and hyphens,
+ * so strip anything else. (CWE-79 / CWE-116; OWASP A03: Injection.)
+ */
+function sanitizeFontFamily(name: string): string {
+    return name.replace(/[^\w \-]/g, '').trim();
+}
+
 function generateFontCss(fonts: FontOptions): string {
     const parts: string[] = [];
+    const textFont = sanitizeFontFamily(fonts.textFont);
+    const codeFont = sanitizeFontFamily(fonts.codeFont);
 
-    if (fonts.textFont) {
+    if (textFont) {
         parts.push(`
 /* Custom text font */
 [class*="root_"]:not([class*="thinkingContent_"] [class*="root_"]) > :is(p, ul, ol, h1, h2, h3, h4, blockquote),
@@ -447,17 +464,17 @@ function generateFontCss(fonts: FontOptions): string {
 [class*="content_"],
 [class*="messageInputContainer_"] [contenteditable],
 [class*="mentionMirror_"] {
-    font-family: "${fonts.textFont}", sans-serif !important;
+    font-family: "${textFont}", sans-serif !important;
 }`);
     }
 
-    if (fonts.codeFont) {
+    if (codeFont) {
         parts.push(`
 /* Custom code font */
 pre,
 code,
 [class*="codeBlockWrapper_"] {
-    font-family: "${fonts.codeFont}", monospace !important;
+    font-family: "${codeFont}", monospace !important;
 }
 
 /* Diff editor — Monaco sets font-family as inline style, needs !important */
@@ -466,7 +483,7 @@ code,
 [class*="diffEditorWrapper_"] .margin-view-overlays,
 [class*="diffEditorWrapper_"] .cursor,
 [class*="diffEditorWrapper_"] .inputarea {
-    font-family: "${fonts.codeFont}", monospace !important;
+    font-family: "${codeFont}", monospace !important;
 }`);
     }
 
@@ -476,19 +493,21 @@ code,
 /** Generate font CSS for Plan Preview — scoped to #content (independent of RTL state). */
 function generatePlanFontCss(fonts: FontOptions): string {
     const parts: string[] = [];
+    const textFont = sanitizeFontFamily(fonts.textFont);
+    const codeFont = sanitizeFontFamily(fonts.codeFont);
 
-    if (fonts.textFont) {
+    if (textFont) {
         parts.push(`
 #content {
-    font-family: "${fonts.textFont}", sans-serif !important;
+    font-family: "${textFont}", sans-serif !important;
 }`);
     }
 
-    if (fonts.codeFont) {
+    if (codeFont) {
         parts.push(`
 #content pre,
 #content code {
-    font-family: "${fonts.codeFont}", monospace !important;
+    font-family: "${codeFont}", monospace !important;
 }`);
     }
 


### PR DESCRIPTION
## Summary

`claude-code-rtl.textFont` and `claude-code-rtl.codeFont` are interpolated into injected CSS **without sanitization**. These settings are read with `vscode.workspace.getConfiguration`, which includes **workspace** scope, so their value can be controlled by a repository's `.vscode/settings.json` when a user opens an (otherwise trusted) workspace.

## Where

`getFontOptions()` in `src/extension.ts` reads the raw values:

```ts
textFont: cfg.get<string>('textFont', '').trim(),
codeFont: cfg.get<string>('codeFont', '').trim(),
```

They are interpolated straight into `font-family: "${...}"`:

- `generateFontCss` / `generatePlanFontCss` (`src/content.ts`), appended to `webview/index.css`; and
- `injectPlanPreview` (`src/injector.ts`), which inserts that CSS **before `</style>`** inside the Plan Preview template in Claude Code's `extension.js` — i.e. inside a `<style>` block in the webview's HTML.

## Impact

A value that closes the quoted string and the rule breaks out into arbitrary CSS, and on the Plan Preview path it can break out of the `<style>` element into the webview's HTML. Example workspace setting:

```json
{ "claude-code-rtl.textFont": "Arial\"; } </style><script>/* attacker */</script>" }
```

Whether an injected inline `<script>` actually executes depends on the Plan Preview webview's CSP (a nonce-based CSP would block inline scripts). But even with a strict CSP this is still CSS/markup injection into Claude Code's webview from a workspace-controlled value (panel defacement, CSS-based data exfiltration, UI redressing). Config changes trigger automatic re-injection, so opening the repository is enough — no further user action is required.

**Classification:** OWASP A03:2021 – Injection; CWE-79 (Cross-site Scripting); CWE-116 (Improper Neutralization / Output Encoding).

## Fix

Add `sanitizeFontFamily()` and apply it wherever the value is interpolated. Font-family names are letters, digits, spaces and hyphens, so anything else is stripped — which neutralizes the string / rule / `<style>` breakout while preserving legitimate names:

```
in : "Arial\"; } </style><script>alert(1)</script>"
out: "Arial  stylescriptalert1script"   // no  " ; { } < > ( )  remain

"JetBrains Mono"  ->  "JetBrains Mono"   // legitimate names unchanged
```

Sanitizing at the sink (both `generateFontCss` and `generatePlanFontCss`) keeps the guarantee even if another caller constructs a `FontOptions` value.

Built and typechecked clean: `npm run build` and `tsc -p tsconfig.json --noEmit` both pass.
