### PR TITLE
fix: abort Plan Preview injection when the JS anchor is missing (no CSS-only partial)

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -286,13 +286,20 @@ async function injectPlanPreview(
             const readyMsg = "vscode.postMessage({ type: 'ready' })";
             const readyIdx = content.indexOf(readyMsg, newAnchorIdx);
             if (readyIdx === -1) {
-                messages.push('  Plan: Could not locate JS injection point in Plan Preview template');
-            } else {
-                content = content.substring(0, readyIdx) +
-                    jsContent + '\n      ' +
-                    content.substring(readyIdx);
-                messages.push('  Plan: RTL JS injected into Plan Preview');
+                // CSS anchor found but JS anchor missing (e.g. a Claude Code version
+                // that kept the template but changed the `ready` message). Abort rather
+                // than persist a CSS-only injection that isPlanPreviewInstalled/getStatus
+                // would then report as INSTALLED — a half-applied feature (no toggle
+                // button, no auto-detect) with no signal to the user. Nothing has been
+                // written to disk yet, so returning here leaves extension.js untouched.
+                messages.push('  Plan: Could not locate JS injection point; aborting to avoid a CSS-only partial injection');
+                return false;
             }
+
+            content = content.substring(0, readyIdx) +
+                jsContent + '\n      ' +
+                content.substring(readyIdx);
+            messages.push('  Plan: RTL JS injected into Plan Preview');
         }
 
         // Corruption guard: Plan Preview injection only inserts content, so the


### PR DESCRIPTION
## Problem

`injectPlanPreview` (`src/injector.ts`) injects CSS before `</style>` and then, when `jsContent` is provided, injects JS before the `vscode.postMessage({ type: 'ready' })` anchor.

If the CSS anchor is found but the **JS anchor is not** — e.g. a Claude Code release that keeps the Plan Preview template but changes the `ready` message wording — the code only logs a note and **still writes the CSS and returns `true`**:

```ts
if (readyIdx === -1) {
    messages.push('  Plan: Could not locate JS injection point in Plan Preview template');
} else {
    // ...inject JS...
}
// ...falls through, writes CSS, returns true
```

`isPlanPreviewInstalled()` only checks the CSS marker (`PLAN_CSS_START_MARKER`), so `getStatus()` then reports Plan Preview as **INSTALLED** while the user actually has RTL styling with **no toggle button (Active mode) and no auto-detection (Auto mode)** — a silently half-applied feature, with no signal that half of it is missing.

## Fix

When `jsContent` is provided and the JS anchor is missing, abort (`return false`) instead of persisting a CSS-only injection. Nothing has been written to disk at that point (the `atomicWrite` happens afterward), so `extension.js` is left untouched and the status is reported honestly as not-installed.

Built and typechecked clean: `npm run build` and `tsc -p tsconfig.json --noEmit` both pass.
