### PR TITLE
fix: refresh the status bar when a mode change is a no-op

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,8 +67,14 @@ async function handleMode(
 
     if (anyChanged) {
         vscode.commands.executeCommand('workbench.action.reloadWindow');
-    } else if (noChangeMessage) {
-        vscode.window.showInformationMessage(noChangeMessage);
+    } else {
+        if (noChangeMessage) {
+            vscode.window.showInformationMessage(noChangeMessage);
+        }
+        // No files changed, so no window reload runs to re-run activation and
+        // refresh the status bar. saveMode() above already persisted the new mode,
+        // so refresh the indicator here to keep it in sync with the saved mode.
+        await updateStatusBar();
     }
 }
 


### PR DESCRIPTION
## Problem

`handleMode()` (`src/extension.ts`) persists the new mode with `saveMode()` and then reloads the window only when a file actually changed (`anyChanged`). When the requested mode is already applied (no file change), it shows a toast and returns **without refreshing the status bar**:

```ts
await saveMode(mode);
if (anyChanged) {
    vscode.commands.executeCommand('workbench.action.reloadWindow');
} else if (noChangeMessage) {
    vscode.window.showInformationMessage(noChangeMessage);
}
```

The window reload is what normally re-runs activation and refreshes the indicator, so on the no-op path the status-bar text can disagree with the just-saved mode until the next activation.

## Fix

Call `await updateStatusBar()` on the no-change path so the indicator stays in sync with the persisted mode. (`updateStatusBar` is already imported.)

Built and typechecked clean: `npm run build` and `tsc -p tsconfig.json --noEmit` both pass.
